### PR TITLE
stop showing join community button for mini communities

### DIFF
--- a/public/scripts/client.js
+++ b/public/scripts/client.js
@@ -5,6 +5,9 @@
 $(document).ready(function() {
 
 	$(window).on('action:ajaxify.end', function() {
+		var parentCid = ajaxify.data.parentCid
+		var isTeamCommunity = parentCid > 0
+		if (isTeamCommunity) return
 
 		if (app.template === 'category' && app.user.uid) {
 			var unsubscribeHtml = '<button type="button" class="btn btn-default btn-warning unsubscribe">[[categorynotifications:unsubscribe]]</button>';


### PR DESCRIPTION
Makes sure that "Join" and "Leave" buttons for communities don't show up for team communities.